### PR TITLE
chore: update required Terraform version to 1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        tf-version: [ 1.1.9, 1.2.9, 1.3.2 ]
+        tf-version: [ 1.3.2 ]
     steps:
       - name: Install terraform v${{ matrix.tf-version }}
         run: |

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/examples/override_both/providers.tf
+++ b/examples/override_both/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/examples/override_fluentbit/providers.tf
+++ b/examples/override_fluentbit/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/examples/override_operator/providers.tf
+++ b/examples/override_operator/providers.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -9,5 +9,5 @@ terraform {
       version = "2.5.2"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Update the required version of Terraform in multiple provider 
configuration files from ">= 1.1.9" to ">= 1.3" to ensure 
compatibility with newer features and improvements. This change 
enhances stability and aligns with current best practices.